### PR TITLE
Update plugin.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,7 @@ fulcrum install-plugin --name s3
 ### Configuration
 
 ```
-./run sync --org 'Fulcrum Account Name' --s3-access-key-id "key" --s3-secret-access-key "secret" --s3-bucket "mybucket"
+./run sync --org "Fulcrum Account Name" --s3-access-key-id "key" --s3-secret-access-key "secret" --s3-bucket "mybucket" --s3-region "us-west-1"
 ```
+
+_Note:_ When pushing to buckets in regions other than us-east-1 you must have AWS_REGION set by using the `--s3-region` parameter.

--- a/plugin.js
+++ b/plugin.js
@@ -29,6 +29,10 @@ export default class {
         s3Bucket: {
           desc: 'S3 bucket',
           type: 'string'
+        },
+        s3Region: {
+          desc: 'S3 region',
+          type: 'string'
         }
       },
       handler: this.runCommand
@@ -50,7 +54,8 @@ export default class {
   async activate() {
     AWS.config.update({
       accessKeyId: fulcrum.args.s3AccessKeyId || process.env.S3_ACCESS_KEY,
-      secretAccessKey: fulcrum.args.s3SecretAccessKey || process.env.S3_ACCESS_SECRET
+      secretAccessKey: fulcrum.args.s3SecretAccessKey || process.env.S3_ACCESS_SECRET,
+      region: fulcrum.args.s3Region || process.env.AWS_REGION
     });
 
     this.s3 = new AWS.S3();


### PR DESCRIPTION
When pushing to buckets in regions other than `us-east-1` you must have `AWS_REGION` set. For Windows users, I think we need to handle this as a parameter in their sync command.